### PR TITLE
Upgrade to Spring Boot 3 with jakarta APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.18</version>
+        <version>3.2.5</version>
         <relativePath/>
         <!--  lookup parent from repository  -->
     </parent>
@@ -181,6 +181,22 @@
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.management</groupId>
+            <artifactId>jakarta.management-api</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
+            <version>2.1.2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>

--- a/src/main/java/ch/mno/copper/collect/collectors/JmxCollector.java
+++ b/src/main/java/ch/mno/copper/collect/collectors/JmxCollector.java
@@ -4,7 +4,7 @@ import ch.mno.copper.collect.connectors.JmxConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.management.*;
+import jakarta.management.*;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/ch/mno/copper/collect/collectors/WebCollector.java
+++ b/src/main/java/ch/mno/copper/collect/collectors/WebCollector.java
@@ -12,7 +12,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.management.*;
+import jakarta.management.*;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/main/java/ch/mno/copper/collect/connectors/JmxConnector.java
+++ b/src/main/java/ch/mno/copper/collect/connectors/JmxConnector.java
@@ -2,10 +2,10 @@ package ch.mno.copper.collect.connectors;
 
 import lombok.extern.log4j.Log4j2;
 
-import javax.management.*;
-import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
-import javax.management.remote.JMXServiceURL;
+import jakarta.management.*;
+import jakarta.management.remote.JMXConnector;
+import jakarta.management.remote.JMXConnectorFactory;
+import jakarta.management.remote.JMXServiceURL;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/ch/mno/copper/daemon/JmxServerStarter.java
+++ b/src/main/java/ch/mno/copper/daemon/JmxServerStarter.java
@@ -4,12 +4,12 @@ import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Disabled;
 
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
-import javax.management.StandardMBean;
-import javax.management.remote.JMXConnectorServer;
-import javax.management.remote.JMXConnectorServerFactory;
-import javax.management.remote.JMXServiceURL;
+import jakarta.management.MBeanServer;
+import jakarta.management.ObjectName;
+import jakarta.management.StandardMBean;
+import jakarta.management.remote.JMXConnectorServer;
+import jakarta.management.remote.JMXConnectorServerFactory;
+import jakarta.management.remote.JMXServiceURL;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.net.MalformedURLException;

--- a/src/main/java/ch/mno/copper/web/CopperAdminServices.java
+++ b/src/main/java/ch/mno/copper/web/CopperAdminServices.java
@@ -20,7 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;

--- a/src/main/java/ch/mno/copper/web/CopperUserServices.java
+++ b/src/main/java/ch/mno/copper/web/CopperUserServices.java
@@ -21,11 +21,11 @@ import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.*;

--- a/src/main/java/ch/mno/copper/web/filters/CORSFilter.java
+++ b/src/main/java/ch/mno/copper/web/filters/CORSFilter.java
@@ -2,7 +2,7 @@ package ch.mno.copper.web.filters;
 
 import org.springframework.stereotype.Service;
 
-import javax.servlet.*;
+import jakarta.servlet.*;
 import java.io.IOException;
 
 @Service

--- a/src/main/java/ch/mno/copper/web/filters/CopperSecurityContext.java
+++ b/src/main/java/ch/mno/copper/web/filters/CopperSecurityContext.java
@@ -1,6 +1,6 @@
 package ch.mno.copper.web.filters;
 
-import javax.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.SecurityContext;
 import java.security.Principal;
 
 public class CopperSecurityContext implements SecurityContext {

--- a/src/main/java/ch/mno/copper/web/filters/LoggingRequestFilter.java
+++ b/src/main/java/ch/mno/copper/web/filters/LoggingRequestFilter.java
@@ -5,10 +5,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.SecurityContext;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.SecurityContext;
 
 public class LoggingRequestFilter extends OncePerRequestFilter {
 

--- a/src/main/java/ch/mno/copper/web/helpers/InstantHelper.java
+++ b/src/main/java/ch/mno/copper/web/helpers/InstantHelper.java
@@ -1,6 +1,6 @@
 package ch.mno.copper.web.helpers;
 
-import javax.ws.rs.QueryParam;
+import jakarta.ws.rs.QueryParam;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;

--- a/src/main/java/ch/mno/copper/web/security/CustomAuthenticationFilter.java
+++ b/src/main/java/ch/mno/copper/web/security/CustomAuthenticationFilter.java
@@ -4,12 +4,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.filter.GenericFilterBean;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.regex.Pattern;
 

--- a/src/main/java/ch/mno/copper/web/security/WebSecurity.java
+++ b/src/main/java/ch/mno/copper/web/security/WebSecurity.java
@@ -1,15 +1,16 @@
 package ch.mno.copper.web.security;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter;
 
 @Configuration
 @EnableWebSecurity
-public class WebSecurity extends WebSecurityConfigurerAdapter {
+public class WebSecurity {
 
 
     @Value("${copper.security.adminHeader:#{null}}")
@@ -20,11 +21,12 @@ public class WebSecurity extends WebSecurityConfigurerAdapter {
 
 
     // Delegate to CustomAuthenticationFilter
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.addFilterAfter(new CustomAuthenticationFilter(adminHeader, adminRegex), WebAsyncManagerIntegrationFilter.class)
-                .csrf().disable();
-        http.headers().frameOptions().disable();
+                .csrf(csrf -> csrf.disable());
+        http.headers(headers -> headers.frameOptions(frame -> frame.disable()));
+        return http.build();
     }
 
 }

--- a/src/main/java/config/CopperStoriesProperties.java
+++ b/src/main/java/config/CopperStoriesProperties.java
@@ -2,7 +2,7 @@ package config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 @ConfigurationProperties(prefix = "stories")
 public class CopperStoriesProperties {

--- a/src/test/java/ch/mno/copper/collect/connectors/HttpConnectorTestController.java
+++ b/src/test/java/ch/mno/copper/collect/connectors/HttpConnectorTestController.java
@@ -6,8 +6,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @RestController

--- a/src/test/java/ch/mno/copper/collect/connectors/JmxConnectorTest.java
+++ b/src/test/java/ch/mno/copper/collect/connectors/JmxConnectorTest.java
@@ -4,7 +4,7 @@ import ch.mno.copper.AbstractJmxServerTestStarter;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import javax.management.*;
+import jakarta.management.*;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/src/test/java/ch/mno/copper/report/MailReporterTest.java
+++ b/src/test/java/ch/mno/copper/report/MailReporterTest.java
@@ -4,8 +4,8 @@ import ch.mno.copper.collect.connectors.ConnectorException;
 import org.apache.commons.mail.HtmlEmail;
 import org.junit.jupiter.api.Test;
 
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -6,7 +6,7 @@
     <logger name="org.apache" level="WARN" />
     <logger name="org.hibernate" level="WARN" />
 
-    <logger name="javax.management.remote" level="TRACE"/>
+    <logger name="jakarta.management.remote" level="TRACE"/>
 
     <root level="TRACE">
         <appender-ref ref="CONSOLE" />


### PR DESCRIPTION
## Summary
- update Spring Boot parent to 3.2.5
- migrate code from `javax` to `jakarta`
- rework security configuration to provide a `SecurityFilterChain` bean

## Testing
- `mvn test -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862be3286b88333b98e506dd4661e95